### PR TITLE
Allow re-attachment of cropperjs

### DIFF
--- a/addon/components/image-cropper.js
+++ b/addon/components/image-cropper.js
@@ -18,8 +18,15 @@ export default Component.extend({
   cropper: null,
   options: null,
 
-  didInsertElement() {
+  didReceiveAttrs() {
     this._super(...arguments);
+
+    let cropper = get(this, 'cropper');
+
+    if (cropper) {
+      cropper.destroy();
+      set(this, 'cropper', null);
+    }
 
     run.scheduleOnce('afterRender', this, this._setup);
   },


### PR DESCRIPTION
If `source` attr is changed, the previous instance of cropperjs should be destroyed to allow new instance of cropperjs for the new image source. `didInsertElement` hook is changed `didReceiveAttrs` to make the component reactive to attr change.