### PR TITLE
Fix for ember-template-lint error

### DIFF
--- a/addon/templates/components/image-cropper.hbs
+++ b/addon/templates/components/image-cropper.hbs
@@ -1,9 +1,11 @@
-<img id={{concat 'image-cropper-' elementId}} src={{source}} alt={{alt}}>
+<img id={{concat "image-cropper-" elementId}} src={{source}} alt={{alt}}>
 
 {{#if _cropper}}
-  {{yield (hash
-    cropper=_cropper
-    call=(component 'image-cropper-call' obj=_cropper)
-    on=(component 'image-cropper-on' cropper=_cropper eventSource=_cropper.element)
-  )}}
+  {{yield
+    (hash
+      cropper=_cropper
+      call=(component "image-cropper-call" obj=_cropper)
+      on=(component "image-cropper-on" cropper=_cropper eventSource=_cropper.element)
+    )
+  }}
 {{/if}}


### PR DESCRIPTION
ember 3.4 comes with `ember-cli-template-lint` added by default. This commit fixes the errors generated by the template linter.