### PR TITLE
Re-initialize cropper when zoomable option changes.

### DIFF
--- a/tests/integration/components/image-cropper-test.js
+++ b/tests/integration/components/image-cropper-test.js
@@ -93,11 +93,11 @@ module('Integration | Component | image cropper', function(hooks) {
     assert.equal(spy.callCount, 2, 'spy.callCount after set');
   });
 
-  test('it constructs a new cropper instance when options.cropBoxMovable changes', async function(assert) {
+  test('it constructs a new cropper instance when options.zoomable changes', async function(assert) {
     const spy = this.sandbox.spy(this.Cropper.prototype, 'init');
 
     this.set('options', {
-      cropBoxMovable: false
+      zoomable: false
     });
 
     await render(hbs`{{image-cropper options=options}}`);
@@ -105,7 +105,7 @@ module('Integration | Component | image cropper', function(hooks) {
     assert.equal(spy.callCount, 1, 'spy.callCount before set');
 
     this.set('options', {
-      cropBoxMovable: true
+      zoomable: true
     });
 
     assert.equal(spy.callCount, 2, 'spy.callCount after set');


### PR DESCRIPTION
This also fixes a problem where the crop data and source weren't being
reloaded when the cropper is re-initialized.

Fixes #33

https://github.com/danielthall/ember-cropperjs/issues/33

Note that in the new test case, the diff makes it look like it's
replacing a previous test, but actually there was an exact duplicate of
the last test in the file.