### PR TITLE
Simplify CSS file import

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,22 +12,9 @@ module.exports = {
     }
   },
 
-  treeForStyles(tree) {
-    var cropperJSTree = require('broccoli-funnel')(require('path').dirname(require.resolve('cropperjs')), {
-      files: ['cropper.css'],
-      destDir: 'app/styles'
-    });
-
-    if (tree) {
-      return require('broccoli-merge-trees')([ tree, cropperJSTree ]);
-    }
-
-    return cropperJSTree;
-  },
-
   included(app) {
     this._super.included.apply(this, arguments);
 
-    app.import('app/styles/cropper.css');
+    app.import('node_modules/cropperjs/dist/cropper.css');
   }
 };


### PR DESCRIPTION
ember-cli has had the option to import directly from `node_modules` for quite some time now via `this.import()` and this pattern is also known to work with https://github.com/embroider-build/embroider/.

/cc @ynotdraw 