### PR TITLE
Fix ember-auto-import babel plugin to be compatible with embroider

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,7 @@ module.exports = function(defaults) {
     babel: {
       plugins: [
         // Ensure that `ember-auto-import` can handle the dynamic imports
-        require('ember-auto-import/babel-plugin')
+        require.resolve('ember-auto-import/babel-plugin')
       ]
     }
   });

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     babel: {
       plugins: [
         // Ensure that `ember-auto-import` can handle the dynamic imports
-        require('ember-auto-import/babel-plugin')
+        require.resolve('ember-auto-import/babel-plugin')
       ]
     }
   },


### PR DESCRIPTION
When building the consuming app with Embroider, we get the following error: `ReferenceError: emberAutoImportDynamic is not defined`. 

This is because `ember-auto-import` should be ignored when using Embroider and these changes fix using babel plugin in a way it is detectable by embroider.

Also `ember-auto-import` docs advise in this direction: https://github.com/ef4/ember-auto-import