### PR TITLE
updated cli-htmlbars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cropperjs",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Ember wrapper around vanilla cropperjs",
   "keywords": [
     "ember-addon",
@@ -24,26 +24,25 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "broccoli-funnel": "^2.0.0",
-    "broccoli-merge-trees": "^3.0.0",
+    "broccoli-funnel": "^3.0.0",
+    "broccoli-merge-trees": "^4.0.0",
     "cropperjs": "~1.4.1",
-    "ember-auto-import": "^1.2.13",
+    "ember-auto-import": "^2.7.2",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^2.0.1"
+    "ember-cli-htmlbars": "^6.0.1"
   },
   "devDependencies": {
-    "babel-eslint": "^9.0.0",
-    "broccoli-asset-rev": "^2.7.0",
-    "ember-cli": "~3.3.0",
-    "ember-cli-addon-docs": "^0.5.3",
-    "ember-cli-addon-docs-yuidoc": "^0.2.1",
-    "ember-cli-dependency-checker": "^2.0.0",
-    "ember-cli-deploy": "^1.0.2",
-    "ember-cli-deploy-build": "^1.1.1",
+    "babel-eslint": "^10.1.0",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-cli": "~4.0.1",
+    "ember-cli-addon-docs": "^6.0.0",
+    "ember-cli-addon-docs-yuidoc": "^1.1.0",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-deploy": "^2.0.0",
+    "ember-cli-deploy-build": "^3.0.0",
     "ember-cli-deploy-git": "^1.3.3",
     "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-eslint": "^4.2.3",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-shims": "^1.2.0",
@@ -52,16 +51,16 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
-    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-maybe-import-regenerator": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-sinon": "^2.1.0",
-    "ember-source": "~3.3.0",
+    "ember-source": "~4.0.1",
     "ember-source-channel-url": "^1.0.1",
-    "ember-try": "^0.2.23",
-    "eslint-plugin-ember": "^5.0.1",
-    "eslint-plugin-node": "^6.0.1",
-    "loader.js": "^4.2.3",
-    "qunit-dom": "^0.6.2"
+    "ember-try": "^3.0.0",
+    "eslint-plugin-ember": "^10.5.8",
+    "eslint-plugin-node": "^11.1.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^2.0.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
updated ember-cli-htmlbars version(v6.0.1) in package.json...
(if we using old html bar version in ember >=4.0, it's throw ember is not defined error)